### PR TITLE
for those request URI without / at the ending

### DIFF
--- a/lib/Net/Amazon/Signature/V4.pm
+++ b/lib/Net/Amazon/Signature/V4.pm
@@ -93,7 +93,7 @@ sub _canonical_request {
 		( $req->uri =~ m@(.*?)\?(.*)$@ )
 		? ( $1, $2 )
 		: ( $req->uri, '' );
-	$creq_canonical_uri =~ s@^https?://.*?/@/@;
+	$creq_canonical_uri =~ s@^https?://.*?(/|$)@/@;
 	$creq_canonical_uri = _simplify_uri( $creq_canonical_uri );
 	$creq_canonical_query_string = _sort_query_string( $creq_canonical_query_string );
 


### PR DESCRIPTION
like when I query with URI of https://search-elasticsearch-abc.eu-west-1.es.amazonaws.com

it works good if I have '/' after .com, but it fails without that.

Thanks