### PR TITLE
allow use of assume role credentials for S3 signed URLs

### DIFF
--- a/lib/Net/Amazon/Signature/V4.pm
+++ b/lib/Net/Amazon/Signature/V4.pm
@@ -48,13 +48,12 @@ Note that the access key ID is an alphanumeric string, not your account ID. The 
 
 sub new {
 	my $class = shift;
-	my ( $access_key_id, $secret, $endpoint, $service ) = @_;
-	my $self = {
-		access_key_id => $access_key_id,
-		secret        => $secret,
-		endpoint      => $endpoint,
-		service       => $service,
-	};
+	my $self = {};
+	if (int(@_) > 1) {
+		@{$self}{qw/ access_key_id secret endpoint service /} = @_;
+	} else {
+		$self = $_[0];
+	}
 	bless $self, $class;
 	return $self;
 }
@@ -113,6 +112,9 @@ sub _canonical_request {
 	my $amz_date = $req->header('x-amz-date');
 	if (!$amz_date) {
 		$req->header('X-Amz-Date' => _req_timepiece($req)->strftime('%Y%m%dT%H%M%SZ'));
+	}
+	if ($self->{security_token} && not($req->header('X-Amz-Security-Token'))) {
+		$req->header('X-Amz-Security-Token' => $self->{security_token});
 	}
 	my @sorted_headers = _headers_to_sign( $req );
 	my $creq_canonical_headers = join '',

--- a/t/10-aws-tests.t
+++ b/t/10-aws-tests.t
@@ -11,40 +11,49 @@ my $testsuite_dir = 't/aws4_testsuite';
 my @test_names = qw/get-header-key-duplicate get-header-value-order get-header-value-trim get-relative get-relative-relative get-slash get-slash-dot-slash get-slashes get-slash-pointless-dot get-space get-unreserved get-utf8 get-vanilla get-vanilla-empty-query-key get-vanilla-query get-vanilla-query-order-key get-vanilla-query-order-key-case get-vanilla-query-order-value get-vanilla-query-unreserved get-vanilla-ut8-query get-zero post-header-key-case post-header-key-sort post-header-value-case post-vanilla post-vanilla-empty-query-value post-vanilla-query post-vanilla-query-nonunreserved post-vanilla-query-space post-x-www-form-urlencoded post-x-www-form-urlencoded-parameters/; # all tests
 # only .req is supplied for test "get-header-value-multiline"; why?
 
-plan tests =>  1+4*@test_names;
-
-my $sig = Net::Amazon::Signature::V4->new(
+my   @a_signer;
+push @a_signer, Net::Amazon::Signature::V4->new(
 	'AKIDEXAMPLE',
 	'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
 	'us-east-1',
 	'host',
 );
+push @a_signer, Net::Amazon::Signature::V4->new({
+        access_key_id 	=> 'AKIDEXAMPLE',
+        secret 		=> 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY',
+        endpoint 	=> 'us-east-1',
+        service 	=> 'host',
+});
+
+plan tests => 1 + ((4 * int(@test_names)) * int(@a_signer));
 
 ok( -d $testsuite_dir, 'testsuite directory existence' );
 
-for my $test_name ( @test_names ) {
+for my $sig ( @a_signer ) {
+	for my $test_name ( @test_names ) {
 
-	ok( -f "$testsuite_dir/$test_name.req", "$test_name.req existence" );
-	my $req = HTTP::Request->parse( read_text( "$testsuite_dir/$test_name.req" ) );
+		ok( -f "$testsuite_dir/$test_name.req", "$test_name.req existence" );
+		my $req = HTTP::Request->parse( read_text( "$testsuite_dir/$test_name.req" ) );
 
-	#diag("$test_name creq");
-	my $creq = $sig->_canonical_request( $req );
-	if ( ! string_fits_file( $creq, "$testsuite_dir/$test_name.creq" ) ) {
-		fail( "canonical request mismatch, string-to-sign can't pass" );
-		fail( "canonical request mismatch, authorization can't pass" );
-		next;
+		#diag("$test_name creq");
+		my $creq = $sig->_canonical_request( $req );
+		if ( ! string_fits_file( $creq, "$testsuite_dir/$test_name.creq" ) ) {
+			fail( "canonical request mismatch, string-to-sign can't pass" );
+			fail( "canonical request mismatch, authorization can't pass" );
+			next;
+		}
+
+		#diag("$test_name sts");
+		my $sts = $sig->_string_to_sign( $req );
+		if ( ! string_fits_file( $sts, "$testsuite_dir/$test_name.sts" ) ) {
+			fail( "string-to-sign request mismatch, authorization can't pass" );
+			next;
+		}
+
+		#diag("$test_name authz");
+		my $authz = $sig->_authorization( $req );
+		string_fits_file( $authz, "$testsuite_dir/$test_name.authz" );
 	}
-
-	#diag("$test_name sts");
-	my $sts = $sig->_string_to_sign( $req );
-	if ( ! string_fits_file( $sts, "$testsuite_dir/$test_name.sts" ) ) {
-		fail( "string-to-sign request mismatch, authorization can't pass" );
-		next;
-	}
-
-	#diag("$test_name authz");
-	my $authz = $sig->_authorization( $req );
-	string_fits_file( $authz, "$testsuite_dir/$test_name.authz" );
 }
 
 sub string_fits_file {


### PR DESCRIPTION
To create SigV4 signed urls with credentials which were determined using
AssumeRole, the security token needs to be added to the request as well.

Signed-off-by: Maik Hentsche <caldrin@amazon.com>