### PR TITLE
Fix "Use of uninitialized value in length" warning with 5.10

### DIFF
--- a/lib/Net/Amazon/Signature/V4.pm
+++ b/lib/Net/Amazon/Signature/V4.pm
@@ -115,7 +115,7 @@ sub _canonical_request {
 
 	# Ensure Host header is present as its required
 	if (!$req->header('host')) {
-		my $host = length $req->uri->_port ? $req->uri->host_port : $req->uri->host;
+		my $host = $req->uri->_port ? $req->uri->host_port : $req->uri->host;
 		$req->header('Host' => $host);
 	}
 	my $creq_payload_hash = $req->header('x-amz-content-sha256');


### PR DESCRIPTION
_port() can return `undef`, `length undef` produces a warning on older perl

As far as port 0 cannot be used as a service port it's safe to just evaluate
port number as boolean.